### PR TITLE
Add in Code of Conduct and main Contributing Guidelines (for all of Data Together GitHub)

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+Online or off, Data Together is a harrassment-free environment for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion or technical skill level. We do not tolerate harassment of participants in any form.
+
+Harassment includes verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behaviour, the organizers may take any action they deem appropriate, including warning the offender or expulsion from events and online forums.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the organizing team immediately.
+
+Organizers will be happy to help participants contact local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your participation!
+
+This document is based on a similar code from [EDGI](https://envirodatagov.org/) and [Civic Tech Toronto](http://civictech.ca/about-us/), itself derived from the [Recurse Center’s Social Rules](https://www.recurse.com/manual#sec-environment), and the [anti-harassment policy from the Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -8,6 +8,6 @@ If a participant engages in harassing behaviour, the organizers may take any act
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the organizing team immediately.
 
-Organizers will be happy to help participants contact local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your participation!
+At offline events, organizers will idnetify themselves, and will help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your participation!
 
 This document is based on a similar code from [EDGI](https://envirodatagov.org/) and [Civic Tech Toronto](http://civictech.ca/about-us/), itself derived from the [Recurse Center’s Social Rules](https://www.recurse.com/manual#sec-environment), and the [anti-harassment policy from the Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing Guidelines
+
+We love improvements to our tools! There are a few key ways you can help us improve our projects:
+
+## Discussing Possibilities for Data Together
+
+We are engaging in a collaborative discussion about project aims and goals, the best place to join in is on [github.com/datatogether/](https://github.com/datatogether/) and all are welcome to join [our Slack chat](https://archivers-slack.herokuapp.com/).
+
+## Submitting Feedback, Requests, and Bugs
+
+Submitting feedback or feature requests and reporting bugs usually begins by
+opening a [GitHub issues](https://help.github.com/articles/about-issues/)
+
+Almost all repositories have their own set of issues:
+
+        https://github.com/datatogether/<repository-name>/issues
+
+Some projects have additional templates or sets of questions for each issue, which you will be prompted to fill out when creating one.
+
+## Submitting Code and Documentation Changes
+
+We have [project guidelines](https://github.com/datatogether/roadmap/PROJECT.md)
+for all of the projects hosted in our
+[GitHub Organization](https://github.com/datatogether), which all repositories
+should follow.
+
+Our process for accepting changes operates by
+[Pull Request (PR)](https://help.github.com/articles/about-pull-requests/) and
+has a few steps:
+
+1.  If you haven't submitted anything before, and you aren't (yet!) a member of
+our organization, **fork and clone** the repo:
+
+        $ git clone git@github.com:<your-username>/<repository-name>.git
+
+    Organization members should clone the upsteam repo, instead of working from
+    a personal fork:
+
+        $ git clone git@github.com:datatogether/<repository-name>.git
+
+1.  Create a **new branch** for the changes you want to work on. Choose a topic
+for your branch name that reflects the change:
+
+        $ git checkout -b <branch-name>
+
+1.  **Create or modify the files** with your changes. If you want to show other
+people work that isn't ready to merge in, commit your changes then create a pull
+request (PR) with _WIP_ or _Work In Progress_ in the title.
+
+        https://github.com/datatogether/<repository-name>/pull/new/master
+
+1.  Once your changes are ready for final review, commit your changes then
+modify or **create your pull request (PR)**. Next, assign an active lead as a
+reviewer or ping them (using "`@<username>`")
+
+1.  Allow others sufficient **time for review and comments** before pinging
+again. We make use of GitHub's review feature to comment in-line on PRs when
+possible. There may be some fixes or adjustments you'll have to make based on
+feedback.
+
+1.  Once you have integrated comments, or waited for feedback, a lead should
+merge your changes in!
+
+_These guidelines are based on
+[EDGI](https://github.com/edgi-govdata-archiving/) and
+[Toronto Mesh](https://github.com/tomeshnet)'s._


### PR DESCRIPTION
Per discussion in https://github.com/datatogether/roadmap/issues/16, here is one based off the CoC from EDGI. *This should be reviewed (and hopefully) merged in prior to the Doc Sprint*

This is different than the partially implemented Contributor Covenant in some repos, I would suggest removing all of those and flipping to a Contributing doc in each repo with points to this CoC  (as part of the doc-sprint).

Once the dust settles and our docs are more in order, we can have a longer discussion about appropriate CoC (it kind of stalled out last time :))



