### PR TITLE
direct new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![License](https://img.shields.io/github/license/datatogether/learning.svg?style=flat-square)](./LICENSE)
 
 ### <em>Community Patterns for the Decentralized Web</em>
+
 We're building a better future for data [on our beta platform](https://archivers.co). come join us!
+
 ## License
 
 <span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Data Together Documentation Materials</span> are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
@@ -16,7 +18,7 @@ We are engaging in a collaborative process to more clearly describe Data Togethe
 
 If you would like to **add to the discussion and submit changes**, please see our [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduct](https://github.com/datatogether/datatogether/blob/master/CONDUCT.md). 
 
-If you just want to **get into the code and start hacking**, then [webapp](https://github.com/datatogether/sentry) and [sentry](http://github.com/datatogether/sentry) are pobably the best points of entry.
+If you want to **get into the code and start hacking**, then [webapp](https://github.com/datatogether/sentry) and [sentry](http://github.com/datatogether/sentry) are the best points of entry.
 
 We use GitHub issues for [tracking ideas and errors](https://github.com/datatogether/datatogether/issues) and Pull Requests (PRs) for [submitting changes](https://github.com/datatogether/datatogether/pulls). Every repository has its own issue tracker so please be sure to post your issues in the best place!
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/datatogether/learning.svg?style=flat-square)](./LICENSE)
 
 ### <em>Community Patterns for the Decentralized Web</em>
-
+We're building a better future for data [on our beta platform](https://archivers.co). come join us!
 ## License
 
 <span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Data Together Documentation Materials</span> are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
@@ -14,9 +14,11 @@
 
 We are engaging in a collaborative process to more clearly describe Data Together so that the initiative can be better understood by newcomers. This process began during an in-person meeting in Boston on August 29, 2017 with [@dcwalk](https://github.com/dcwalk), [@flyingzumwalt](https://github.com/flyingzumwalt), [@jeffreyliu](https://github.com/jeffreyliu), [@mhucka](https://github.com/mhucka), [@ebarry](https://github.com/ebarry), [@b5](https://github.com/b5), [@jschell42](https://github.com/jschell42), [@titaniumbones](https://github.com/titaniumbones), [@rgardaphe](https://github.com/rgardaphe). We are starting with time-tested patterns from non-profits, collaboratives, and companies: Mission, Vision, Values. Please click on the links below to see and comment on the draft text:
 
-If you would like to add to the discussion and submit changes, please see our [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduct](https://github.com/datatogether/datatogether/blob/master/CONDUCT.md). 
+If you would like to **add to the discussion and submit changes**, please see our [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduct](https://github.com/datatogether/datatogether/blob/master/CONDUCT.md). 
 
-We use GitHub issues for [tracking ideas and errors](https://github.com/datatogether/datatogether/issues) and Pull Requests (PRs) for [submitting changes](https://github.com/datatogether/datatogether/pulls).
+If you just want to **get into the code and start hacking**, then [webapp](https://github.com/datatogether/sentry) and [sentry](http://github.com/datatogether/sentry) are pobably the best points of entry.
+
+We use GitHub issues for [tracking ideas and errors](https://github.com/datatogether/datatogether/issues) and Pull Requests (PRs) for [submitting changes](https://github.com/datatogether/datatogether/pulls). Every repository has its own issue tracker so please be sure to post your issues in the best place!
 
 ## Mission
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### <em>Community Patterns for the Decentralized Web</em>
 
-We're building a better future for data [on our beta platform](https://archivers.co). come join us!
+ We're building a better future for data. The [beta platform at https://archivers.co](https://archivers.co) is one example of where we're going. Come join us!
 
 ## License
 


### PR DESCRIPTION
just brief language to make sure contributors know how to get to sentry and webapp.

We should have another line for new endorsers, but I'm not sure what we want to do with them, so...