### PR TITLE
add issue template to support range of DT conversations

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+Thanks for adding to the conversation around Data Together 🎉
+
+In addition to general thoughts and questions we have a couple defined ways to explore topics, examples, challenges or opportunities:
+- Question, get right to whatever is on your mind
+- Roundtable, help host a guided 30-min discussion during our standing rountable time
+
+Check out the templates below, if they don't cover what you need, go freeform!
+
+---
+
+Title: Question: [short form of your quesitons]
+
+[Ask your question! Tho try to keep it to a single question Provide some additional context, links to other resources are always good :)]
+
+---
+
+Title: Roundtable: [topic]
+
+[1-2 context description, highlighting open questions or areas that need to be expanded on]
+
+Willing to Host: [your name if you are!]  
+Preparation: [identify any todos, links, helpful resources that people should check out]  
+[-✂︎-delete this comment, but everything below here stays-✂︎-]  
+Call notes: https://docs.google.com/document/d/1GMSHYFYN4NRVvLdUmgFWmYa2Kny2vdRTitc3Ixu2woU/edit# 
+
+🙋🏻‍♀️ _what are [**weekly roundtables**](https://github.com/datatogether/datatogether/blob/master/guidelines/roundtable.md) anyway? They are discussions of a Data Together-related topic, challenge, or question led by a rotating facilitator. If you are hosting, be sure to check out [**how to host**](https://github.com/datatogether/datatogether/blob/master/guidelines/roundtable.md#how-to-host) (and add any improvements!)_

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,9 +8,9 @@ Check out the templates below, if they don't cover what you need, go freeform!
 
 ---
 
-Title: Question: [short form of your quesitons]
+Title: [short form of your questions]
 
-[Ask your question! Tho try to keep it to a single question Provide some additional context, links to other resources are always good :)]
+[Ask your question! Tho try to keep it to a single question. Providing additional context and links to other resources are always good :)]
 
 ---
 


### PR DESCRIPTION
Something I was thinking on, only fuzzy.

Basically --> we use this repo mainly for discussions and managing questions, roundtables, how about creating an issue template that reflects that?

Eventually having this supported by/supporting the website and an engagement funnel #34 makes sense