### PR TITLE
Update link to webapp in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Welcome to [Data Together](https://datatogether.org/), we're building a better f
 
 If you would like to **add to the discussion**, please see our [Contributing Guidelines](./CONTRIBUTING.md) and [Code of Conduct](https://github.com/datatogether/datatogether/blob/master/CONDUCT.md). 
 
-If you want to **get into code and start hacking**, check out [first timer](https://github.com/issues?q=is:open+org:datatogether+label:first-timers-only) issues! [Webapp](https://github.com/datatogether/sentry) and [sentry](http://github.com/datatogether/sentry) are the best points of entry. We track project progress using a [Waffle Board](https://waffle.io/datatogether/roadmap) and identify major goals in our [Roadmap repository](https://github.com/datatogether/roadmap/).
+If you want to **get into code and start hacking**, check out [first timer](https://github.com/issues?q=is:open+org:datatogether+label:first-timers-only) issues! [Webapp](https://github.com/datatogether/webapp) and [sentry](http://github.com/datatogether/sentry) are the best points of entry. We track project progress using a [Waffle Board](https://waffle.io/datatogether/roadmap) and identify major goals in our [Roadmap repository](https://github.com/datatogether/roadmap/).
 
 ### Community Calendar
 


### PR DESCRIPTION
The old link was pointing to https://github.com/datatogether/sentry